### PR TITLE
Fix maintenance bug (incl. new clean-up method)

### DIFF
--- a/rapo/main/scheduler.py
+++ b/rapo/main/scheduler.py
@@ -405,7 +405,6 @@ class Scheduler():
                 self._clean()
                 self.maintenance.clear()
                 logger.info('Maintenance performed')
-                break
             time.sleep(1)
         pass
 


### PR DESCRIPTION
Two maintenance related commits:

1. Fixes the bug in the scheduler's `_maintain` function that causes the maintenace thread *Thread-Maintainer* to be terminated after the first execution (`break` in the `while` loop of the thread function) so it doesn't run again until scheduler process is restarted. 

2. Implements additional clean-up method (use `truncate table` instead of `delete from ...`) when days_retention=0 (performance related issue reported by Claro Peru)